### PR TITLE
Challenge: sort HN results by title length, comments and score

### DIFF
--- a/hacker-news-scraper/data/scraperResponse.go
+++ b/hacker-news-scraper/data/scraperResponse.go
@@ -1,5 +1,10 @@
 package data
 
 type ScraperResponse struct {
-	Title string `json:"title"`
+	Order    int    `json:"order"`
+	Id       string `json:"id"`
+	Title    string `json:"title"`
+	Url      string `json:"url"`
+	Comments int    `json:"comments"`
+	Score    int    `json:"score"`
 }

--- a/hacker-news-scraper/main.go
+++ b/hacker-news-scraper/main.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/IntelligenzCodeLab/hacker-news-scraper/data"
 	"github.com/IntelligenzCodeLab/hacker-news-scraper/services"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
+	"strconv"
 )
 
 const hnApiUrl = "https://hacker-news.firebaseio.com/v0"
-const maxReturnItems = 10
+const maxReturnItems = 30
 
 func RetrieveHackerNewsItems(retriever services.Retriever) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
@@ -27,7 +29,13 @@ func RetrieveHackerNewsItems(retriever services.Retriever) http.HandlerFunc {
 		w.WriteHeader(http.StatusOK)
 		response := make([]data.ScraperResponse, len(items))
 		for i, item := range items {
-			response[i] = data.ScraperResponse{Title: item.Title}
+			title := item.Title
+			num := i + 1
+			comments := item.Descendants
+			id := int(item.Id)
+			score := item.Score
+			fmt.Printf("%d - Title(%d): %s (%d comments, score %d). Id: %d\n", num, len(title), title, comments, score, id)
+			response[i] = data.ScraperResponse{Order: num, Id: strconv.Itoa(id), Title: title, Url: item.Url, Comments: comments, Score: score}
 		}
 		err = json.NewEncoder(w).Encode(response)
 		if err != nil {


### PR DESCRIPTION
Take the first 30 entries from the Hacker News API:and then it will sort them in the following manner:
 * First come entries with more than 5 words in their title
 * Long title entries will then be sorted by number of comments
 * Short title entries will be sorted by number of points
Then sorted entries will be printed out by console output.